### PR TITLE
get_side_to_move()で使うコマンドを"moves"から"side"へ修正

### DIFF
--- a/source/shogi/Ayane.py
+++ b/source/shogi/Ayane.py
@@ -589,7 +589,7 @@ class UsiEngine():
     # [SYNC] usi_position()で設定した局面に対する手番を得る。
     # "side"は、やねうら王でしか使えないUSI拡張コマンド
     def get_side_to_move(self) -> Turn:
-        line = self.__send_command_and_getline("moves")
+        line = self.__send_command_and_getline("side")
         return Turn.BLACK if line == "black" else Turn.WHITE
 
 
@@ -703,7 +703,7 @@ class UsiEngine():
                 # positionコマンドは、WaitCommand状態でないと送信できない。
                 elif token == "position":
                     self.wait_for_state(UsiEngineState.WaitCommand)
-                elif token == "moves":
+                elif token == "moves" or token == "side":
                     self.wait_for_state(UsiEngineState.WaitCommand)
                     self.__change_state(UsiEngineState.WaitOneLine)
                 elif token == "usinewgame" or token == "gameover":


### PR DESCRIPTION
get_side_to_move()でエンジンへ送信するコマンドが"moves"になっていましたので"side"へ修正しました。
あわせて__write_worker()の方もsideコマンドに対応するコードを追加しました。
