### PR TITLE
AyaneruServerのgame_start()で1P側のエンジンのget_side_to_move()を呼ぶ前にusi_positi…

### DIFF
--- a/source/shogi/Ayane.py
+++ b/source/shogi/Ayane.py
@@ -1083,6 +1083,7 @@ class AyaneruServer:
             engine.error_print = self.error_print
         
         # 1P側のエンジンを使って、現局面の手番を得る。
+        self.engines[0].usi_position(self.sfen)
         self.side_to_move = self.engines[0].get_side_to_move()
         self.game_ply = 1
         self.game_result = GameResult.PLAYING


### PR DESCRIPTION
…on()で開始局面をセットするよう修正

AyaneruServerのgame_start()で1P側のエンジンのget_side_to_move()を呼ぶ前にusi_position()で開始局面をセットするように修正しました。
unit_test1.pyのtest_ayane6（マルチあやねるサーバーを使った対局例）で出力される棋譜と対局結果について
これまでは実際の棋譜とBLACK_WIN/WHITE_WINが合っていない場合があったようです（結果的にP1とP2の勝敗数も正しくなかったような気がします...）。
MultiAyaneruServerの中でAyaneruServerを使い回していると思いますが、
2回目以降のgame_start()で1P側のエンジンのget_side_to_move()を呼ぶと、
今回の対局の開始局面ではなく前回の対局の投了局面の手番が返ってきていたため、
AyaneruServer側で管理しているside_to_moveと実際の局面のside_to_moveがずれてしまっていたように思います。
