### PR TITLE
時間切れ判定で秒読みを考慮していなかった点を修正

### DIFF
--- a/source/shogi/Ayane.py
+++ b/source/shogi/Ayane.py
@@ -1092,14 +1092,14 @@ class AyaneruServer:
             # 現在の手番を数値化したもの。1P側=0 , 2P側=1
             int_turn = self.player_number(self.side_to_move)
             self.__rest_time[int_turn] -= int(elapsed_time)
-            if self.__rest_time[int_turn] < -2000:  # -2秒より減っていたら。0.1秒対局とかもあるので1秒繰り上げで引いていくとおかしくなる。
+            if self.__rest_time[int_turn] + self.__time_setting[byoyomi_str] < -2000:  # 秒読み含めて-2秒より減っていたら。0.1秒対局とかもあるので1秒繰り上げで引いていくとおかしくなる。
                 self.game_result = GameResult.from_win_turn(self.side_to_move.flip())
                 self.__game_over()
                 # 本来、自己対局では時間切れになってはならない。(計測が不確かになる)
                 # 警告を表示しておく。
                 print("Error! : player timeup")
                 return
-            # 残り時間がわずかにマイナスになっていたら0に戻しておく。
+            # 残り時間がマイナスになっていたら0に戻しておく。
             if self.__rest_time[int_turn] < 0:
                 self.__rest_time[int_turn] = 0
 


### PR DESCRIPTION
AyaneruServer内において時間切れ判定をするときに秒読みを考慮していないと思われます。判定部分で2秒のマージンを取っているのでそれ以内だと切れないのですが、たとえばunit_test1.pyでもtest_ayane5の秒読み部分(https://github.com/SakodaShintaro/Ayane/blob/master/source/unit_test1.py#L205)を5秒などにするとtimeupになりました。

この直し方で良いかどうかはやや自信がありませんが適当にやっていただけたら幸いです。