### PR TITLE
mate +のparseに失敗するのを修正

### DIFF
--- a/source/shogi/Ayane.py
+++ b/source/shogi/Ayane.py
@@ -808,7 +808,7 @@ class UsiEngine:
                         # "info depth 1 nodes 0 time 0 score mate + string Nyugyoku"
                         # のような文字列が来ることがあるらしい。
                         is_minus = scanner.peek_token()[0] == '-'
-                        ply = int(scanner.get_integer())  # pylintが警告を出すのでintと明示しておく。
+                        ply = scanner.get_integer()
                         # 解析失敗したときはNoneが返ってくるので、このとき手数は+2000/-2000という扱いにしておく。
                         # これはUsiEvalSpecialValueでmate scoreとして判定されるギリギリのスコア。
                         if ply is None:


### PR DESCRIPTION
試すのが遅くなってしまいましたが、「info depth 1 nodes 0 time 0 score mate + string Nyugyoku」についてまだParse失敗するようでした。
```
 ply = int(scanner.get_integer())  # pylintが警告を出すのでintと明示しておく。
```
この行で入力が「+」のとき```scanner.get_integer()```が```None```を返すのでそれを```int```にしようとして例外が発生するようです。ただ```int( )```を外すだけで良いのですが、警告は……まぁなんか上手くやっておいてください（あるいはこのプルリクを蹴るのでも良いですが）