### PR TITLE
サンプルコードの修正

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ USIプロトコルのエンジンであれば他のエンジンでもpythonか�
 # 使い方
 
 ```python
-import shogi.Ayane
+import shogi.Ayane as ayane
 
 # 通常探索用の思考エンジンの接続テスト
 # 同期的に思考させる。


### PR DESCRIPTION
```python
import shogi.Ayane as ayane
```

にしないと読み込めないので（サンプルコードを見ればわかるのですが）、一応。